### PR TITLE
Add Connection Failed & Rename ApiError

### DIFF
--- a/lib/cortex/exceptions.rb
+++ b/lib/cortex/exceptions.rb
@@ -28,5 +28,12 @@ module Cortex
     class IdExpected < ArgumentError; end
 
     class IdNotExpected < ArgumentError; end
+
+    class ConnectionFailed < CortexError
+      attr_reader :base_url
+      def initialize(base_url = "http://api.cbcortex.com/api/v1/")
+        @base_url = base_url
+      end
+    end
   end
 end

--- a/lib/cortex/exceptions.rb
+++ b/lib/cortex/exceptions.rb
@@ -33,6 +33,7 @@ module Cortex
       attr_reader :base_url
       def initialize(base_url = "http://api.cbcortex.com/api/v1/")
         @base_url = base_url
+        super
       end
     end
   end

--- a/lib/cortex/exceptions.rb
+++ b/lib/cortex/exceptions.rb
@@ -4,7 +4,7 @@ module Cortex
   module Exceptions
     class CortexError < StandardError; end
 
-    class CortexAPIError < CortexError
+    class ApiError < CortexError
       attr_accessor :http_status
 
       def initialize(message = 'Internal server error', http_status = :internal_server_error)
@@ -13,13 +13,13 @@ module Cortex
       end
     end
 
-    class NotEmptyError < CortexAPIError
+    class NotEmptyError < ApiError
       def initialize(message = nil)
         super(message, :conflict)
       end
     end
 
-    class ResourceConsumed < CortexAPIError
+    class ResourceConsumed < ApiError
       def initialize(message = 'Resource is in use by another resource and cannot be deleted', http_status = :unprocessable_entity)
         super(message)
       end

--- a/lib/cortex/exceptions.rb
+++ b/lib/cortex/exceptions.rb
@@ -25,16 +25,16 @@ module Cortex
       end
     end
 
+    class ConnectionFailed < APIError
+      attr_reader :base_url
+      def initialize(base_url = "http://api.cbcortex.com/api/v1/", message = nil, http_status = 599)
+        @base_url = base_url
+        super(message: message, http_status: http_status)
+      end
+    end
+
     class IdExpected < ArgumentError; end
 
     class IdNotExpected < ArgumentError; end
-
-    class ConnectionFailed < CortexError
-      attr_reader :base_url
-      def initialize(base_url = "http://api.cbcortex.com/api/v1/")
-        @base_url = base_url
-        super
-      end
-    end
   end
 end

--- a/lib/cortex/exceptions/version.rb
+++ b/lib/cortex/exceptions/version.rb
@@ -1,5 +1,5 @@
 module Cortex
   module Exceptions
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
CortexAPIError was redundant, given the Cortex::Exceptions namespace already on it. I've renamed to Cortex::Exceptions::ApiError.

Adds ConnectionFailed, a subclass of ApiError. I used 599 as it's the most similar value I could find, but open to suggestions.
